### PR TITLE
Add DELETE /api/v0/pipeline-nodes/:id with transactions, error handli…

### DIFF
--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -4,7 +4,7 @@ use async_nats::{
     jetstream::{self},
 };
 use axum::{
-    routing::{get, post},
+    routing::{get, post, delete},
     Router,
 };
 use db::seed::seed_database;
@@ -166,6 +166,10 @@ async fn main() -> io::Result<()> {
         .route(
             "/pipeline-nodes/:id",
             post(routes::api::v0::pipeline_nodes::update),
+        )
+        .route(
+            "/pipeline-nodes/:id",
+            delete(routes::api::v0::pipeline_nodes::delete)
         )
         .route(
             "/pipeline-node-connections",


### PR DESCRIPTION
Hi,
I've implemented the DELETE `/api/v0/pipeline-nodes/:id` endpoint as requested in #20. Here’s what’s included:

- **Functionality**: Deletes a pipeline node along with its connections, inputs, and outputs.
- **Transactions**: Ensures all deletions are atomic using SQLx transactions.
- **Error Handling**: Returns 404 if the node isn’t found and 500 with JSON error details on failure, improving on the previous `internal_error` approach.
- **Logging**: Added `tracing::info` logs for start and success, aligning with the project’s observability setup.
- **Tests**: Included two integration tests (`test_delete_pipeline_node_success` and `test_delete_pipeline_node_not_found`) to verify behavior.

**Note**:
-  Unable to run `cargo sqlx prepare` to update query cache. Someone with database access needs to run it.

The code is tested locally with a mock database URL, so please adjust the test URL to match your setup. Let me know if there’s anything else to tweak or if I should add authorization checks (I skipped them since they weren’t specified in the issue).

Looking forward to feedback!